### PR TITLE
Changed description on how to import the styles file to use angular.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,26 +26,33 @@ npm install angular-shepherd --save
 **NOTE: This may not be the proper Angular way to do everything, as I am not
 an Angular dev, so please let me know if you have suggestions!**
 
-First, you will want to include the Shepherd styles in your application component template.
-To import from `node_modules`, you will need to use `ViewEncapsulation.None` and add the
-`node_modules` relative path to your `styleUrls`.
+First, you will want to include the Shepherd styles in your angular application. If you are using angular cli you can import the styles in the styles section of angular.json. 
 
-```typescript
-// app.component.ts
-
-import { Component, ViewEncapsulation } from '@angular/core';
-
-@Component({
-  selector: 'app-root',
-  encapsulation: ViewEncapsulation.None,
-  templateUrl: './app.component.html',
-  styleUrls: [
-    './app.component.css',
-    '../../../../node_modules/shepherd.js/dist/css/shepherd-theme-default.css'
-  ]
-})
-export class AppComponent {
-  title = 'shepherd-tester';
+```json
+{
+  "projects": {
+    "app": {
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "styles": [
+              "node_modules/shepherd.js/dist/css/shepherd-theme-default.css",
+              "src/styles.scss"
+            ],
+          },
+        },
+        "test": {
+          "options": {
+            "styles": [
+              "node_modules/shepherd.js/dist/css/shepherd-theme-default.css",
+              "src/styles.scss"
+            ],
+          }
+        },
+      }
+    },
+  },
 }
 ```
 

--- a/angular.json
+++ b/angular.json
@@ -58,6 +58,7 @@
               "projects/shepherd-tester/src/assets"
             ],
             "styles": [
+              "node_modules/shepherd.js/dist/css/shepherd-theme-default.css",
               "projects/shepherd-tester/src/styles.css"
             ],
             "scripts": [],

--- a/projects/shepherd-tester/src/app/app.component.ts
+++ b/projects/shepherd-tester/src/app/app.component.ts
@@ -2,11 +2,9 @@ import { Component, ViewEncapsulation } from '@angular/core';
 
 @Component({
   selector: 'app-root',
-  encapsulation: ViewEncapsulation.None,
   templateUrl: './app.component.html',
   styleUrls: [
     './app.component.css',
-    '../../../../node_modules/shepherd.js/dist/css/shepherd-theme-default.css'
   ]
 })
 export class AppComponent {


### PR DESCRIPTION
I updated the description to use a more conform way to include the shepherd stylesheet in an angular application. This is appliccable for projects created with angular cli. Not sure if we should include an alternative way of including the styles when one is not using angular cli.

Just a small note to your old text in the docs:

    To import from node_modules, you will need to use ViewEncapsulation.None

You can include styles from node_modules without setting view encapsulation to none. The point is, if you don't set this property the styles will be included, but they will only be limited to the component where you include them in and will not cascade down to other components. By setting view encapsulation to none the imported styles are applicable for the full application and not only the component.