### PR TITLE
Update repository url in package.json

### DIFF
--- a/projects/shepherd/package.json
+++ b/projects/shepherd/package.json
@@ -8,7 +8,11 @@
     "site tour",
     "tour"
   ],
-  "repository": "https://github.com/shipshapecode/angular-shepherd",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/shipshapecode/angular-shepherd.git"
+  },
+  "homepage": "https://github.com/shipshapecode/angular-shepherd",
   "license": "MIT",
   "author": {
     "name": "Robert Wagner",


### PR DESCRIPTION
This will ensure that the package page in npmjs.com will show a link to the Github page, since now its not.

https://www.npmjs.com/package/angular-shepherd